### PR TITLE
Set custom truststore if JENKINS_CA_CERT env variable is set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Optional environment variables:
 * `JENKINS_TUNNEL`: (`HOST:PORT`) connect to this agent host and port instead of Jenkins server, assuming this one do route TCP traffic to Jenkins master. Useful when when Jenkins runs behind a load balancer, reverse proxy, etc.
 * `JENKINS_SECRET`: agent secret, if not set as an argument
 * `JENKINS_AGENT_NAME`: agent name, if not set as an argument
+* `JENKINS_CA_CERT`: path to Jenkins master CA certificate, required to establish JNLP-4 connections.
 
 ## Configuration specifics
 

--- a/jenkins-slave
+++ b/jenkins-slave
@@ -75,8 +75,20 @@ else
 		fi
 	fi
 
+	# JENKINS_CA_CERT points a path for ca cert (possibly mounted as a secret volume)
+	if [ -n "$JENKINS_CA_CERT" ]; then
+		jre_keystore=/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts
+		keystore_dir=$HOME/.keystore
+		mkdir -p $keystore_dir
+		cp $jre_keystore $keystore_dir
+		cat $JENKINS_CA_CERT > /tmp/cacert
+		keytool -import -keystore $keystore_dir/cacerts -alias master -file /tmp/cacert -storepass changeit -noprompt
+		rm /tmp/cacert
+		TRUSTSTORE="-Djavax.net.ssl.trustStore=$HOME/.keystore/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+	fi
+
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-	exec java $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+	exec java $JAVA_OPTS $TRUSTSTORE $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
 fi


### PR DESCRIPTION
If users using private certificate with Jenkins master wants
to use JNLP 4 protocol, they should set the JENKINS_CA_CERT
env variable to the PEM encoded bytes of ca certificate.

Fixes https://github.com/appscode-ci/cibox/issues/16#issuecomment-295727123